### PR TITLE
Use pix_fmt of AVCodecContext instead of fixed pixel format

### DIFF
--- a/h264_image_transport/src/h264_subscriber.cpp
+++ b/h264_image_transport/src/h264_subscriber.cpp
@@ -136,7 +136,7 @@ void H264Subscriber::internalCallback(
 
   // Set / update sws context
   p_sws_context_ = sws_getCachedContext(
-    p_sws_context_, p_frame_->width, p_frame_->height, AV_PIX_FMT_YUV420P,
+    p_sws_context_, p_frame_->width, p_frame_->height, p_codec_context_->pix_fmt,
     p_frame_->width, p_frame_->height, AV_PIX_FMT_BGR24,
     SWS_FAST_BILINEAR, nullptr, nullptr, nullptr);
 


### PR DESCRIPTION
Thanks for this nice package!
Instead of assuming AV_PIX_FMT_YUV420P, this information can be extracted from the stream through p_codec_context_->pix_fmt.